### PR TITLE
Descriptive Comments - command chown -R flag

### DIFF
--- a/0-setup_web_static.sh
+++ b/0-setup_web_static.sh
@@ -12,8 +12,8 @@ sudo mkdir -p /data/web_static/releases/test/
 echo "Holberton School" | sudo tee /data/web_static/releases/test/index.html > /dev/null
 sudo ln -sf /data/web_static/releases/test/ /data/web_static/current
 
-# The command chown -hR is used to change the ownership of files and directories recursively
-sudo chown -hR ubuntu:ubuntu /data/
+# The command chown -R is used to change the ownership of files and directories recursively
+sudo chown -R ubuntu:ubuntu /data/
 
 # configure nginx
 sudo sed -i '44i \\n\tlocation /hbnb_static {\n\t\talias /data/web_static/current/;\n\t}' /etc/nginx/sites-available/default

--- a/0-setup_web_static.sh
+++ b/0-setup_web_static.sh
@@ -12,8 +12,8 @@ sudo mkdir -p /data/web_static/releases/test/
 echo "Holberton School" | sudo tee /data/web_static/releases/test/index.html > /dev/null
 sudo ln -sf /data/web_static/releases/test/ /data/web_static/current
 
-# set permissions
-sudo chown -R ubuntu:ubuntu /data/
+# The command chown -hR is used to change the ownership of files and directories recursively
+sudo chown -hR ubuntu:ubuntu /data/
 
 # configure nginx
 sudo sed -i '44i \\n\tlocation /hbnb_static {\n\t\talias /data/web_static/current/;\n\t}' /etc/nginx/sites-available/default


### PR DESCRIPTION
# The command chown -R is used to change the ownership of files and directories recursively
sudo chown -R ubuntu:ubuntu /data/

# This command inserts the following block of text at line 44 of the
# /etc/nginx/sites-available/default file
sudo sed -i '44i \\n\tlocation /hbnb_static {\n\t\talias /data/web_static/current/;\n\t}' /etc/nginx/sites-available/default
